### PR TITLE
Fix API_BASE_URL

### DIFF
--- a/Front/.env.example
+++ b/Front/.env.example
@@ -1,1 +1,2 @@
-VITE_BACK_API_BASE_URL=http://localhost:3142
+# Example environment variables for the frontend
+# No frontend-specific variables needed currently

--- a/Front/src/services/base-api.ts
+++ b/Front/src/services/base-api.ts
@@ -1,8 +1,5 @@
-// Get the backend API URL from environment variable or default to localhost
-// Determine the backend API URL from environment variable or default to localhost
-const API_BASE_URL = import.meta.env.VITE_BACK_API_BASE_URL
-  ? import.meta.env.VITE_BACK_API_BASE_URL
-  : 'http://localhost:3142';
+// Backend API URL - matches the port configured in docker-compose.yml
+const API_BASE_URL = 'http://localhost:3142';
 export class BaseApiService {
   protected async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = `${API_BASE_URL}${endpoint}`;

--- a/Front/src/vite-env.d.ts
+++ b/Front/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+// Add Vite environment variable types here if needed in the future

--- a/Front/vite.config.js
+++ b/Front/vite.config.js
@@ -6,9 +6,6 @@ export default defineConfig({
     host: '0.0.0.0',
     allowedHosts: ['pong.fazai.dev', 'devpong.fazai.dev']
   },
-  define: {
-    'import.meta.env.VITE_BACK_API_BASE_URL': JSON.stringify(process.env.VITE_BACK_API_BASE_URL || 'http://localhost:3142')
-  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
This pull request simplifies the configuration for the frontend by removing unused environment variables and hardcoding the backend API URL. It also updates the `vite.config.js` file to clean up unnecessary definitions.

### Simplification of environment variable usage:

* [`Front/.env.example`](diffhunk://#diff-7597646380787b06a98d96b837f142d7f0a4ab9830158fe1bcf7e5083adf46aaL1-R2): Removed the `VITE_BACK_API_BASE_URL` variable and added a comment indicating that no frontend-specific environment variables are currently needed.
* [`Front/src/services/base-api.ts`](diffhunk://#diff-02a33790f7477a7dee09700b1b9f7f07bc74351aa3512944b40fab8a5121ee67L1-R2): Hardcoded the backend API URL (`http://localhost:3142`) instead of dynamically determining it from an environment variable. Updated the comment to reflect this change.

### Cleanup in Vite configuration:

* [`Front/vite.config.js`](diffhunk://#diff-d0aa28742984a77b370ab76134d8842244f9ab94d57fd38d3e9957b4e171b03aL9-L11): Removed the `define` block that previously included `VITE_BACK_API_BASE_URL`, as it is no longer used.